### PR TITLE
Hotfix/dendrite forward

### DIFF
--- a/precog/utils/config.py
+++ b/precog/utils/config.py
@@ -171,7 +171,7 @@ def add_validator_args(parser):
         "--neuron.timeout",
         type=float,
         help="The timeout for each forward call in seconds.",
-        default=10,
+        default=30,
     )
 
     parser.add_argument(

--- a/precog/utils/config.py
+++ b/precog/utils/config.py
@@ -171,7 +171,7 @@ def add_validator_args(parser):
         "--neuron.timeout",
         type=float,
         help="The timeout for each forward call in seconds.",
-        default=30,
+        default=20,
     )
 
     parser.add_argument(

--- a/precog/validators/weight_setter.py
+++ b/precog/validators/weight_setter.py
@@ -146,14 +146,15 @@ class weight_setter:
         # Save updated state
         self.save_state()
 
-    def query_miners(self):
+    async def query_miners(self):
         timestamp = get_str()
         synapse = Challenge(timestamp=timestamp)
-        responses = self.dendrite.query(
+        responses = await self.dendrite.forward(
             # Send the query to selected miner axons in the network.
             axons=[self.metagraph.axons[uid] for uid in self.available_uids],
             synapse=synapse,
             deserialize=False,
+            timeout=self.config.neuron.timeout,
         )
         return responses, timestamp
 
@@ -215,7 +216,7 @@ class weight_setter:
             await asyncio.sleep(600)
         else:
             if is_query_time(self.prediction_interval, self.timestamp) or query_lag >= 60 * self.prediction_interval:
-                responses, self.timestamp = self.query_miners()
+                responses, self.timestamp = await self.query_miners()
                 try:
                     bt.logging.debug(f"Processing responses for UIDs: {self.available_uids}")
                     bt.logging.debug(f"Number of responses: {len(responses)}")


### PR DESCRIPTION
Increase default timeout for validators, and utilize dendrite.forward (an async function) 