### PR TITLE
fix: rounding issue causing hour overflow in timestamp adjustment

### DIFF
--- a/precog/utils/timestamp.py
+++ b/precog/utils/timestamp.py
@@ -185,9 +185,7 @@ def round_to_interval(timestamp: datetime, interval_minutes: int = 5) -> datetim
     rounded_minutes = round(minutes_since_midnight / interval_minutes) * interval_minutes
 
     # Create new timestamp with rounded minutes
-    new_timestamp = utc_timestamp.replace(
-        hour=int(rounded_minutes // 60), minute=int(rounded_minutes % 60), second=0, microsecond=0
-    )
+    new_timestamp = utc_timestamp.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(minutes=rounded_minutes)
 
     return new_timestamp
 


### PR DESCRIPTION
This commit fixes a ValueError: hour must be in 0..23, which occurred when rounding pushed the hour past 23:59, leading to an invalid hour value in utc_timestamp.replace().