### PR TITLE
Bugfix/memory leak

### DIFF
--- a/precog/miners/base_miner.py
+++ b/precog/miners/base_miner.py
@@ -25,7 +25,13 @@ def get_point_estimate(cm: CMData, timestamp: str) -> float:
 
     # Query CM API for a pandas dataframe with only one record
     price_data: pd.DataFrame = cm.get_CM_ReferenceRate(
-        assets="BTC", start=None, end=to_str(provided_timestamp), frequency="1s", limit_per_asset=1, paging_from="end"
+        assets="BTC",
+        start=None,
+        end=to_str(provided_timestamp),
+        frequency="1s",
+        limit_per_asset=1,
+        paging_from="end",
+        use_cache=False,
     )
 
     # Get current price closest to the provided timestamp

--- a/precog/miners/miner.py
+++ b/precog/miners/miner.py
@@ -41,7 +41,7 @@ class Miner:
         self.loop.create_task(self.run())
         self.loop.create_task(loop_handler(self, self.resync_metagraph, sleep_time=self.resync_metagraph_rate))
         self.loop.create_task(loop_handler(self, self.monitor_cm_cache, sleep_time=300))
-        self.loop.create_task(loop_handler(self, self.clear_cm_cache, sleep_time=3600))
+        # self.loop.create_task(loop_handler(self, self.clear_cm_cache, sleep_time=3600))
         self.loop.run_forever()
 
     async def run(self):

--- a/precog/miners/miner.py
+++ b/precog/miners/miner.py
@@ -41,7 +41,6 @@ class Miner:
         self.loop.create_task(self.run())
         self.loop.create_task(loop_handler(self, self.resync_metagraph, sleep_time=self.resync_metagraph_rate))
         self.loop.create_task(loop_handler(self, self.monitor_cm_cache, sleep_time=300))
-        # self.loop.create_task(loop_handler(self, self.clear_cm_cache, sleep_time=3600))
         self.loop.run_forever()
 
     async def run(self):
@@ -68,17 +67,6 @@ class Miner:
             # Fallback if using original CMData without monitoring
             cache_size = len(self.cm._cache) if hasattr(self.cm, "_cache") and not self.cm._cache.empty else 0
             bt.logging.trace(f"CMData cache size: {cache_size} rows")
-
-    async def clear_cm_cache(self):
-        """Periodically clears the CM cache to prevent memory growth."""
-        if hasattr(self.cm, "clear_cache"):
-            bt.logging.info("Running scheduled cache clearing...")
-            self.cm.clear_cache()
-            # Explicitly trigger garbage collection
-            import gc
-
-            gc.collect()
-            bt.logging.info("Cache cleared and garbage collection triggered")
 
     async def resync_metagraph(self):
         bt.logging.info("Syncing Metagraph...")

--- a/precog/miners/miner.py
+++ b/precog/miners/miner.py
@@ -82,7 +82,14 @@ class Miner:
 
     async def resync_metagraph(self):
         bt.logging.info("Syncing Metagraph...")
-        self.metagraph.sync(subtensor=self.subtensor)
+        try:
+            self.metagraph.sync(subtensor=self.subtensor)
+        except Exception as e:
+            bt.logging.debug(f"Failed to sync metagraph: {e}")
+            bt.logging.debug("Instantiating new subtensor")
+            self.subtensor = bt.subtensor(config=self.config, network=self.config.subtensor.chain_endpoint)
+            self.metagraph.sync(subtensor=self.subtensor)
+
         bt.logging.info("Metagraph updated, re-syncing hotkeys, dendrite pool and moving averages")
         self.current_block = func_with_retry(self.subtensor.get_current_block)
 

--- a/precog/miners/miner.py
+++ b/precog/miners/miner.py
@@ -67,7 +67,7 @@ class Miner:
         else:
             # Fallback if using original CMData without monitoring
             cache_size = len(self.cm._cache) if hasattr(self.cm, "_cache") and not self.cm._cache.empty else 0
-            bt.logging.info(f"CMData cache size: {cache_size} rows")
+            bt.logging.trace(f"CMData cache size: {cache_size} rows")
 
     async def clear_cm_cache(self):
         """Periodically clears the CM cache to prevent memory growth."""
@@ -81,7 +81,6 @@ class Miner:
             bt.logging.info("Cache cleared and garbage collection triggered")
 
     async def resync_metagraph(self):
-        # self.subtensor = bt.subtensor(config=self.config, network=self.config.subtensor.chain_endpoint)
         bt.logging.info("Syncing Metagraph...")
         self.metagraph.sync(subtensor=self.subtensor)
         bt.logging.info("Metagraph updated, re-syncing hotkeys, dendrite pool and moving averages")

--- a/precog/utils/cm_data.py
+++ b/precog/utils/cm_data.py
@@ -76,7 +76,6 @@ class CMData:
         Notes:
             CM API Reference: https://coinmetrics.github.io/api-client-python/site/api_client.html#get_pair_candles
         """
-        bt.logging.info(f"Requesting data from {start} to {end}")
 
         if not use_cache:
             return self._fetch_reference_rate(

--- a/precog/utils/cm_data.py
+++ b/precog/utils/cm_data.py
@@ -76,6 +76,8 @@ class CMData:
         Notes:
             CM API Reference: https://coinmetrics.github.io/api-client-python/site/api_client.html#get_pair_candles
         """
+        bt.logging.info(f"Requesting data from {start} to {end}")
+
         if not use_cache:
             return self._fetch_reference_rate(
                 assets, start, end, end_inclusive, frequency, page_size, parallelize, time_inc_parallel, **kwargs

--- a/precog/utils/cm_data.py
+++ b/precog/utils/cm_data.py
@@ -40,7 +40,7 @@ class CMData:
         if "time" in self._cache.columns:
             time_range = f" (time range: {self._cache['time'].min()} to {self._cache['time'].max()})"
 
-        bt.logging.info(f"CMData cache stats: Size={size_mb:.2f}MB, Rows={rows}{time_range}")
+        bt.logging.trace(f"CMData cache stats: Size={size_mb:.2f}MB, Rows={rows}{time_range}")
 
     def get_CM_ReferenceRate(
         self,

--- a/precog/utils/cm_data.py
+++ b/precog/utils/cm_data.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime
 from typing import Optional, Union
 
+import bittensor as bt
 import pandas as pd
 from coinmetrics.api_client import CoinMetricsClient
 
@@ -19,6 +20,27 @@ class CMData:
     @property
     def client(self):
         return self._client
+
+    def get_cache_size_mb(self):
+        """Return the approximate size of the cache in MB."""
+        if self._cache.empty:
+            return 0
+        # Calculate memory usage with deep=True to account for actual object sizes
+        return self._cache.memory_usage(deep=True).sum() / (1024 * 1024)
+
+    def log_cache_stats(self):
+        """Log cache statistics."""
+        if self._cache.empty:
+            bt.logging.info("CMData cache is empty")
+            return
+
+        size_mb = self.get_cache_size_mb()
+        rows = len(self._cache)
+        time_range = ""
+        if "time" in self._cache.columns:
+            time_range = f" (time range: {self._cache['time'].min()} to {self._cache['time'].max()})"
+
+        bt.logging.info(f"CMData cache stats: Size={size_mb:.2f}MB, Rows={rows}{time_range}")
 
     def get_CM_ReferenceRate(
         self,

--- a/precog/validators/weight_setter.py
+++ b/precog/validators/weight_setter.py
@@ -109,12 +109,18 @@ class weight_setter:
         except Exception as e:
             bt.logging.error(f"Error clearing old predictions: {e}")
 
-    async def resync_metagraph(self):
+    async def resync_metagraph(self):  # noqa: C901
         """Resyncs the metagraph and updates the hotkeys, available UIDs, and MinerHistory.
         Ensures all data structures remain in sync."""
-        # Resync subtensor and metagraph
         bt.logging.info("Syncing Metagraph...")
-        self.metagraph.sync(subtensor=self.subtensor)
+        try:
+            self.metagraph.sync(subtensor=self.subtensor)
+        except Exception as e:
+            bt.logging.debug(f"Failed to sync metagraph: {e}")
+            bt.logging.debug("Instantiating new subtensor")
+            self.subtensor = bt.subtensor(config=self.config, network=self.config.subtensor.chain_endpoint)
+            self.metagraph.sync(subtensor=self.subtensor)
+
         bt.logging.info("Metagraph updated, re-syncing hotkeys, dendrite pool and moving averages")
 
         # Get current state for logging

--- a/precog/validators/weight_setter.py
+++ b/precog/validators/weight_setter.py
@@ -113,7 +113,6 @@ class weight_setter:
         """Resyncs the metagraph and updates the hotkeys, available UIDs, and MinerHistory.
         Ensures all data structures remain in sync."""
         # Resync subtensor and metagraph
-        # self.subtensor = bt.subtensor(config=self.config, network=self.config.subtensor.chain_endpoint)
         bt.logging.info("Syncing Metagraph...")
         self.metagraph.sync(subtensor=self.subtensor)
         bt.logging.info("Metagraph updated, re-syncing hotkeys, dendrite pool and moving averages")

--- a/precog/validators/weight_setter.py
+++ b/precog/validators/weight_setter.py
@@ -97,7 +97,7 @@ class weight_setter:
         """Resyncs the metagraph and updates the hotkeys, available UIDs, and MinerHistory.
         Ensures all data structures remain in sync."""
         # Resync subtensor and metagraph
-        self.subtensor = bt.subtensor(config=self.config, network=self.config.subtensor.chain_endpoint)
+        # self.subtensor = bt.subtensor(config=self.config, network=self.config.subtensor.chain_endpoint)
         bt.logging.info("Syncing Metagraph...")
         self.metagraph.sync(subtensor=self.subtensor)
         bt.logging.info("Metagraph updated, re-syncing hotkeys, dendrite pool and moving averages")


### PR DESCRIPTION
Resolve memory leaks in the miner and validator. 

- Periodically clear the MinerHistory object: [https://github.com/umocm/precog-task-tracking/issues/7](url)
- Minimize subtensor instantiation, by reusing the same subtensor initialized on miner/validator startup: [https://github.com/umocm/precog-task-tracking/issues/8](url)
- Only use the cm_data cache for the prediction interval data (24 hours in the base miner)